### PR TITLE
production buildにwebpack-plugin-serveを含めないようにする

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,8 +13,8 @@ return {
     entry: {
       main: [
         path.resolve(__dirname, "src/index.tsx"),
-        'webpack-plugin-serve/client'
-      ]
+        isProduction ? null : 'webpack-plugin-serve/client'
+      ].filter(Boolean)
     },
     output: {
       filename: isProduction ? "bundle.[hash].js" : "[name].js",


### PR DESCRIPTION
production buildでwebpack-plugin-serveが含まれていると実行時にエラーになる

see. https://github.com/shellscape/webpack-plugin-serve/issues/95